### PR TITLE
Enhance FilesystemManager and add DeleteObjectHash RPC

### DIFF
--- a/dfs/common/FilesystemManager.cs
+++ b/dfs/common/FilesystemManager.cs
@@ -1,6 +1,7 @@
 ﻿using Fs;
 using Google.Protobuf;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,11 +12,11 @@ namespace common
 {
     public class FilesystemManager
     {
-        public Dictionary<ByteString, ObjectWithHash> ObjectByHash { get; }
-        public Dictionary<ByteString, ByteString[]> ChunkParents { get; }
-        public Dictionary<Guid, ByteString> Container { get; }
-        public Dictionary<ByteString, List<ByteString>> Parent { get; }
-        public Dictionary<ByteString, ByteString> NewerVersion { get; }
+        public ConcurrentDictionary<ByteString, ObjectWithHash> ObjectByHash { get; }
+        public ConcurrentDictionary<ByteString, ByteString[]> ChunkParents { get; }
+        public ConcurrentDictionary<Guid, ByteString> Container { get; }
+        public ConcurrentDictionary<ByteString, List<ByteString>> Parent { get; }
+        public ConcurrentDictionary<ByteString, ByteString> NewerVersion { get; }
 
         public FilesystemManager()
         {
@@ -116,5 +117,8 @@ namespace common
                 ChunkParents[chunkHash] = [parentHash];
             }
         }
+
+
+
     }
 }

--- a/dfs/common/generated/rpc/Tracker.cs
+++ b/dfs/common/generated/rpc/Tracker.cs
@@ -31,7 +31,7 @@ namespace Tracker {
             "c2gYASABKAwSFgoObWF4X3BlZXJfY291bnQYAiABKAUiFAoESGFzaBIMCgRk",
             "YXRhGAEgASgMIkQKDk9iamVjdFdpdGhIYXNoEiQKBm9iamVjdBgBIAEoCzIU",
             "LmZzLkZpbGVTeXN0ZW1PYmplY3QSDAoEaGFzaBgCIAEoDCIcCgxQZWVyUmVz",
-            "cG9uc2USDAoEcGVlchgBIAEoCTKhAwoHVHJhY2tlchI0CgdQdWJsaXNoEhcu",
+            "cG9uc2USDAoEcGVlchgBIAEoCTLUAwoHVHJhY2tlchI0CgdQdWJsaXNoEhcu",
             "dHJhY2tlci5PYmplY3RXaXRoSGFzaBoOLnRyYWNrZXIuRW1wdHkoARI5Cg1H",
             "ZXRPYmplY3RUcmVlEg0udHJhY2tlci5IYXNoGhcudHJhY2tlci5PYmplY3RX",
             "aXRoSGFzaDABEjAKDU1hcmtSZWFjaGFibGUSDS50cmFja2VyLkhhc2gaDi50",
@@ -40,7 +40,9 @@ namespace Tracker {
             "ci5QZWVyUmVxdWVzdBoVLnRyYWNrZXIuUGVlclJlc3BvbnNlMAESPQoUR2V0",
             "Q29udGFpbmVyUm9vdEhhc2gSFi50cmFja2VyLkNvbnRhaW5lckd1aWQaDS50",
             "cmFja2VyLkhhc2gSQgoUU2V0Q29udGFpbmVyUm9vdEhhc2gSGi50cmFja2Vy",
-            "LkNvbnRhaW5lclJvb3RIYXNoGg4udHJhY2tlci5FbXB0eWIGcHJvdG8z"));
+            "LkNvbnRhaW5lclJvb3RIYXNoGg4udHJhY2tlci5FbXB0eRIxChBEZWxldGVP",
+            "YmplY3RIYXNoEg0udHJhY2tlci5IYXNoGg4udHJhY2tlci5FbXB0eWIGcHJv",
+            "dG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Fs.FilesystemReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {

--- a/dfs/common/generated/rpc/TrackerGrpc.cs
+++ b/dfs/common/generated/rpc/TrackerGrpc.cs
@@ -116,6 +116,14 @@ namespace Tracker {
         __Marshaller_tracker_ContainerRootHash,
         __Marshaller_tracker_Empty);
 
+    [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+    static readonly grpc::Method<global::Tracker.Hash, global::Tracker.Empty> __Method_DeleteObjectHash = new grpc::Method<global::Tracker.Hash, global::Tracker.Empty>(
+        grpc::MethodType.Unary,
+        __ServiceName,
+        "DeleteObjectHash",
+        __Marshaller_tracker_Hash,
+        __Marshaller_tracker_Empty);
+
     /// <summary>Service descriptor</summary>
     public static global::Google.Protobuf.Reflection.ServiceDescriptor Descriptor
     {
@@ -164,6 +172,12 @@ namespace Tracker {
 
       [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
       public virtual global::System.Threading.Tasks.Task<global::Tracker.Empty> SetContainerRootHash(global::Tracker.ContainerRootHash request, grpc::ServerCallContext context)
+      {
+        throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
+      }
+
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual global::System.Threading.Tasks.Task<global::Tracker.Empty> DeleteObjectHash(global::Tracker.Hash request, grpc::ServerCallContext context)
       {
         throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
       }
@@ -287,6 +301,26 @@ namespace Tracker {
       {
         return CallInvoker.AsyncUnaryCall(__Method_SetContainerRootHash, null, options, request);
       }
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual global::Tracker.Empty DeleteObjectHash(global::Tracker.Hash request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      {
+        return DeleteObjectHash(request, new grpc::CallOptions(headers, deadline, cancellationToken));
+      }
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual global::Tracker.Empty DeleteObjectHash(global::Tracker.Hash request, grpc::CallOptions options)
+      {
+        return CallInvoker.BlockingUnaryCall(__Method_DeleteObjectHash, null, options, request);
+      }
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual grpc::AsyncUnaryCall<global::Tracker.Empty> DeleteObjectHashAsync(global::Tracker.Hash request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      {
+        return DeleteObjectHashAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
+      }
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual grpc::AsyncUnaryCall<global::Tracker.Empty> DeleteObjectHashAsync(global::Tracker.Hash request, grpc::CallOptions options)
+      {
+        return CallInvoker.AsyncUnaryCall(__Method_DeleteObjectHash, null, options, request);
+      }
       /// <summary>Creates a new instance of client from given <c>ClientBaseConfiguration</c>.</summary>
       [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
       protected override TrackerClient NewInstance(ClientBaseConfiguration configuration)
@@ -307,7 +341,8 @@ namespace Tracker {
           .AddMethod(__Method_MarkUnreachable, serviceImpl.MarkUnreachable)
           .AddMethod(__Method_GetPeerList, serviceImpl.GetPeerList)
           .AddMethod(__Method_GetContainerRootHash, serviceImpl.GetContainerRootHash)
-          .AddMethod(__Method_SetContainerRootHash, serviceImpl.SetContainerRootHash).Build();
+          .AddMethod(__Method_SetContainerRootHash, serviceImpl.SetContainerRootHash)
+          .AddMethod(__Method_DeleteObjectHash, serviceImpl.DeleteObjectHash).Build();
     }
 
     /// <summary>Register service method with a service binder with or without implementation. Useful when customizing the service binding logic.
@@ -324,6 +359,7 @@ namespace Tracker {
       serviceBinder.AddMethod(__Method_GetPeerList, serviceImpl == null ? null : new grpc::ServerStreamingServerMethod<global::Tracker.PeerRequest, global::Tracker.PeerResponse>(serviceImpl.GetPeerList));
       serviceBinder.AddMethod(__Method_GetContainerRootHash, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Tracker.ContainerGuid, global::Tracker.Hash>(serviceImpl.GetContainerRootHash));
       serviceBinder.AddMethod(__Method_SetContainerRootHash, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Tracker.ContainerRootHash, global::Tracker.Empty>(serviceImpl.SetContainerRootHash));
+      serviceBinder.AddMethod(__Method_DeleteObjectHash, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Tracker.Hash, global::Tracker.Empty>(serviceImpl.DeleteObjectHash));
     }
 
   }

--- a/dfs/common/proto/rpc/tracker.proto
+++ b/dfs/common/proto/rpc/tracker.proto
@@ -13,6 +13,7 @@ service Tracker
 	rpc GetPeerList(PeerRequest) returns (stream PeerResponse);
 	rpc GetContainerRootHash(ContainerGuid) returns (Hash);
 	rpc SetContainerRootHash(ContainerRootHash) returns (Empty);
+	rpc DeleteObjectHash(Hash) returns (Empty);
 }
 
 message Empty

--- a/dfs/node/Program.cs
+++ b/dfs/node/Program.cs
@@ -30,7 +30,7 @@ namespace node
             var server = new Grpc.Core.Server()
             {
                 Services = { Node.Node.BindService(rpc) },
-                Ports = { new ServerPort("localhost", 0, ServerCredentials.Insecure) }
+                Ports = { new ServerPort("localhost", 50331, ServerCredentials.Insecure) }
             };
 
             server.Start();
@@ -43,7 +43,7 @@ namespace node
             NodeService service = new(state, rpc);
 
 
-            if (true) // mock for demo
+            if (false) // mock for demo
             {
                 var file = "C:\\Users\\as\\Documents\\paint.net App Files";
                 var guid = service.ImportObjectFromDisk(file, 1024);

--- a/dfs/tracker/Program.cs
+++ b/dfs/tracker/Program.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Core.Logging;
+using common;
 
 namespace tracker
 {
@@ -10,12 +11,12 @@ namespace tracker
         static async Task Main(string[] args)
         {
             var serverCredentials = ServerCredentials.Insecure;
-
+            FilesystemManager filesystemManager = new FilesystemManager();
             GrpcEnvironment.SetLogger(new LogLevelFilterLogger(
                 new ConsoleLogger(),
                 LogLevel.Debug));
 
-            TrackerRpc rpc = new TrackerRpc();
+            TrackerRpc rpc = new TrackerRpc(filesystemManager);
             var server = new Server
             {
                 Services = { Tracker.Tracker.BindService(rpc) },


### PR DESCRIPTION
- Updated `FilesystemManager` to use `ConcurrentDictionary` for improved thread safety.
- Introduced `DeleteObjectHash` RPC method in `tracker.proto` for object hash deletion.
- Modified `TrackerRpc` to implement the new `DeleteObjectHash` method.
- Updated `Program.cs` to instantiate `FilesystemManager` and set a fixed server port (50331).
- Adjusted mock condition in `Program.cs` for testing purposes.
- Added necessary `using` directives for new functionality.
- Registered `DeleteObjectHash` method in `TrackerGrpc` for client access.